### PR TITLE
Fix Historical Sensor example in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ A Python 3.7 API Class to turn data from the PurpleAir/ThingSpeak API into a Pan
     536249   2019-01-27 00:05:55+00:00             15.16              19.71              20.56           30776.0          0.02           974.05     NaN            19.71
 
 See examples in `/scripts` for more detail.
+


### PR DESCRIPTION
The example code was missing the channel name argument to `get_historical()` which is required for the sample code to run.  Patch 3 fixes spurious missing newline at bottom of file.