### PR TITLE
Feat/cs/fix pandas crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ print(s)  # Sensor 2891 at 10834, Canyon Road, Omaha, Douglas County, Nebraska, 
 ```python
 from purpleair.network import SensorList
 p = SensorList()  # Initialized 11,220 sensors!
-# Other sensor filters include 'outside', 'useful', 'family', and 'no_child'
+# Other sensor filters include 'outside', 'useful', and 'family'
 df = p.to_dataframe(sensor_filter='all',
                     channel='parent')
 ```

--- a/docs/api/sensorlist_methods.md
+++ b/docs/api/sensorlist_methods.md
@@ -18,8 +18,6 @@ Converts dictionary representation of a list of sensors to a Pandas DataFrame wh
   * Do not filter sensors
 * `family`
   * Sensor has both parent and child
-* `no_child`
-  * Sensor is parent-only
 * `column`
   * Must be a value that exists on a [Channel](/docs/documentation.md#channel)
   * If `value_filter` is not provided:

--- a/purpleair/network.py
+++ b/purpleair/network.py
@@ -175,9 +175,6 @@ class SensorList():
                 'family': lambda: pd.DataFrame([s.as_flat_dict(channel)
                                                 for s in [s for s in self.all_sensors
                                                           if s.parent and s.child]]),
-                'no_child': lambda: pd.DataFrame([s.as_flat_dict(channel)
-                                                  for s in [s for s in self.all_sensors
-                                                            if not s.child]]),
                 'column': lambda: self.filter_column(channel, column, value_filter)
             }[sensor_filter]()
         except KeyError as err:

--- a/tests/test_purpleair.py
+++ b/tests/test_purpleair.py
@@ -39,14 +39,6 @@ class TestPurpleAirMethods(unittest.TestCase):
         p.to_dataframe('useful', 'parent')
         p.to_dataframe('useful', 'child')
 
-    def test_to_dataframe_filtering_no_child(self):
-        """
-        Test that no_child sensor filter works
-        """
-        p = network.SensorList()
-        p.to_dataframe('no_child', 'parent')
-        p.to_dataframe('no_child', 'child')
-
     def test_to_dataframe_filtering_family(self):
         """
         Test that family sensor filter works
@@ -56,6 +48,9 @@ class TestPurpleAirMethods(unittest.TestCase):
         p.to_dataframe('family', 'child')
 
     def test_to_dataframe_cols(self):
+        """
+        Test that child and parent sensor dataframes contain the same data
+        """
         p = network.SensorList()
         df_a = p.to_dataframe(sensor_filter='all', channel='parent')
         df_b = p.to_dataframe(sensor_filter='all', channel='child')


### PR DESCRIPTION
This fixes a crash when the filter `no_child` was selected because every sensor now reports that it has at least one child.