### PR TITLE
Fix docs on `location_type` possible values

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -53,7 +53,7 @@ Initialize a new sensor.
     * [Channel](#channel) instance for child data
     * Not all parent data is available from the child sensor
   * `location_type`
-    * The location type of the sensor, one of `{'indoor', 'outdoor', 'unknown'}`
+    * The location type of the sensor, one of `{'inside', 'outside', None}`
   * `location`
     * Location string if `parse_location` was true, otherwise empty string
 


### PR DESCRIPTION
Demo code:

```python
from purpleair.network import SensorList
p = SensorList()  # Initialized 23,145 sensors!
print(set(s.location_type for s in p.all_sensors))
```

Gives: `{'outside', 'inside', None}`

Updated docs to reflect this.
