### PR TITLE
Allow passing optional thingspeak api query params to get_historical

### DIFF
--- a/purpleair/api_data.py
+++ b/purpleair/api_data.py
@@ -4,6 +4,7 @@ Constants for PurpleAir API
 
 
 API_ROOT = 'https://www.purpleair.com/json'
+THINGSPEAK_API_URL = "https://thingspeak.com/channels/{channel}/feed.csv?"
 
 PARENT_PRIMARY_COLS = {
     'created_at': 'created_at',

--- a/purpleair/api_data.py
+++ b/purpleair/api_data.py
@@ -4,7 +4,7 @@ Constants for PurpleAir API
 
 
 API_ROOT = 'https://www.purpleair.com/json'
-THINGSPEAK_API_URL = "https://thingspeak.com/channels/{channel}/feed.csv?"
+THINGSPEAK_API_URL = "https://thingspeak.com/channels/{channel}/feed.{dataformat}?"
 
 PARENT_PRIMARY_COLS = {
     'created_at': 'created_at',

--- a/purpleair/channel.py
+++ b/purpleair/channel.py
@@ -6,20 +6,14 @@ import json
 from datetime import datetime, timedelta
 from typing import Optional
 
-try:
-    # py3
-    from urllib.parse import urlencode
-except ImportError:
-    # py2
-    from urllib import urlencode
+from urllib.parse import urlencode
 
 import pandas as pd
 import thingspeak
 
 from .api_data import (PARENT_PRIMARY_COLS, PARENT_SECONDARY_COLS,
-                       CHILD_PRIMARY_COLS, CHILD_SECONDARY_COLS)
+                       CHILD_PRIMARY_COLS, CHILD_SECONDARY_COLS, THINGSPEAK_API_URL)
 
-THINGSPEAK_API_URL = "https://thingspeak.com/channels/{channel}/feed.csv?"
 
 class Channel():
     """
@@ -161,7 +155,7 @@ class Channel():
     def get_all_historical(self,
                            weeks_to_get: int,
                            start_date: datetime = datetime.now(),
-                           thingspeak_args={}) -> pd.DataFrame:
+                           thingspeak_args=None) -> pd.DataFrame:
         primary = self.get_historical(weeks_to_get, 'primary', start_date, thingspeak_args)
         secondary = self.get_historical(weeks_to_get, 'secondary', start_date, thingspeak_args)
         return pd.merge(primary, secondary, how='inner', on='created_at')
@@ -170,7 +164,7 @@ class Channel():
                        weeks_to_get: int,
                        thingspeak_field: str,
                        start_date: datetime = datetime.now(),
-                       thingspeak_args={}) -> pd.DataFrame:
+                       thingspeak_args=None) -> pd.DataFrame:
         """
         Get data from the ThingSpeak API one week at a time up to weeks_to_get weeks in the past.
         
@@ -196,7 +190,8 @@ class Channel():
         to_week = start_date - timedelta(weeks=1)
         
         # copy args to a local variable
-        thingspeak_args = thingspeak_args.copy()
+        if not thingspeak_args:
+            thingspeak_args = {}
         default_args = {
             'api_key': key,
             'offset': 0,

--- a/purpleair/channel.py
+++ b/purpleair/channel.py
@@ -12,8 +12,13 @@ from urllib import request
 import pandas as pd
 import thingspeak
 
-from .api_data import (PARENT_PRIMARY_COLS, PARENT_SECONDARY_COLS,
-                       CHILD_PRIMARY_COLS, CHILD_SECONDARY_COLS, THINGSPEAK_API_URL)
+from .api_data import (
+    PARENT_PRIMARY_COLS,
+    PARENT_SECONDARY_COLS,
+    CHILD_PRIMARY_COLS,
+    CHILD_SECONDARY_COLS,
+    THINGSPEAK_API_URL)
+
 
 class Channel():
     """
@@ -78,8 +83,8 @@ class Channel():
             'pm10_0_atm')
 
         # Statistics
-        self.pm2_5stats: Optional[dict] = json.loads(self.channel_data['Stats']) \
-            if 'Stats' in self.channel_data else None
+        self.pm2_5stats: Optional[dict] = json.loads(
+            self.channel_data['Stats']) if 'Stats' in self.channel_data else None
         self.m10avg: Optional[float] = self.pm2_5stats.get(
             'v1') if self.pm2_5stats else None
         self.m30avg: Optional[float] = self.pm2_5stats.get(
@@ -151,17 +156,28 @@ class Channel():
         self.created: Optional[int] = self.channel_data.get('Created')
         self.uptime: Optional[int] = self.channel_data.get('Uptime')
         self.is_owner: Optional[bool] = bool(self.channel_data.get('isOwner'))
-        
+
     @property
     def created_date(self):
-        url = self.get_thingspeak_url('primary', start=datetime(1990,1,1), end=None, thingspeak_args={'results': 1}, dataformat='json')
+        url = self.get_thingspeak_url(
+            'primary', start=datetime(
+                1990, 1, 1), end=None, thingspeak_args={
+                'results': 1}, dataformat='json')
         data = json.loads(request.urlopen(url).read())
-        created_at = datetime.strptime(data['channel']['created_at'], '%Y-%m-%dT%H:%M:%SZ')
+        created_at = datetime.strptime(
+            data['channel']['created_at'],
+            '%Y-%m-%dT%H:%M:%SZ')
         return created_at
 
-    def get_thingspeak_url(self, thingspeak_field, start, end=None, thingspeak_args=None, dataformat='csv'):
+    def get_thingspeak_url(
+            self,
+            thingspeak_field,
+            start,
+            end=None,
+            thingspeak_args=None,
+            dataformat='csv'):
         """Build the URL to fetch the thingspeak data
-        
+
         thingspeak_args takes an optional list of additional arguments to send to the Thingspeak API. See here for more details: https://ww2.mathworks.cn/help/thingspeak/readdata.html
         """
 
@@ -189,12 +205,13 @@ class Channel():
         for key, val in default_args.items():
             if key not in thingspeak_args:
                 thingspeak_args[key] = val
-        
+
         thingspeak_args['start'] = start.strftime("%Y-%m-%d 00:00:00")
         if end:
             thingspeak_args['end'] = end.strftime("%Y-%m-%d 00:00:00")
 
-        base_url = THINGSPEAK_API_URL.format(channel=channel, dataformat=dataformat)
+        base_url = THINGSPEAK_API_URL.format(
+            channel=channel, dataformat=dataformat)
         return base_url + urlencode(thingspeak_args)
 
     def clean_data(self, thingspeak_field, data):
@@ -211,7 +228,8 @@ class Channel():
         try:
             data.index = data.pop('entry_id')
         except KeyError:
-            # entry_id isn't always present. E.g. if you use timescale='nonstandard'
+            # entry_id isn't always present. E.g. if you use
+            # timescale='nonstandard'
             pass
         return data
 
@@ -221,43 +239,50 @@ class Channel():
                            thingspeak_args=None) -> pd.DataFrame:
         """
         Get all data (both primary and secondary) from the ThingSpeak API in weekly increments
-        
+
         """
-                           
-        primary = self.get_historical(weeks_to_get, 'primary', start_date, thingspeak_args)
-        secondary = self.get_historical(weeks_to_get, 'secondary', start_date, thingspeak_args)
+
+        primary = self.get_historical(
+            weeks_to_get, 'primary', start_date, thingspeak_args)
+        secondary = self.get_historical(
+            weeks_to_get, 'secondary', start_date, thingspeak_args)
         return pd.merge(primary, secondary, how='inner', on='created_at')
-    
+
     def get_all_historical_between(self,
                                    first_date: datetime,
                                    last_date: datetime = datetime.now(),
                                    thingspeak_args=None) -> pd.DataFrame:
         """
         Get all data (both primary and secondary) from the ThingSpeak API all in one go, staring from first_date up until last_date.
-        
+
         WARNING: For huge date ranges, this may be a large dataset, and take a long time to download. In these situations, get_historical (by week) may be a better option.
-        
+
         """
-        primary = self.get_historical_between('primary', first_date, last_date, thingspeak_args)
-        secondary = self.get_historical_between('secondary', first_date, last_date, thingspeak_args)
+        primary = self.get_historical_between(
+            'primary', first_date, last_date, thingspeak_args)
+        secondary = self.get_historical_between(
+            'secondary', first_date, last_date, thingspeak_args)
         return pd.merge(primary, secondary, how='inner', on='created_at')
-        
+
     def get_historical_between(self,
                                thingspeak_field: str,
                                first_date: datetime,
                                last_date: datetime = datetime.now(),
                                thingspeak_args=None) -> pd.DataFrame:
-
         """
         Get data from the ThingSpeak API all in one go, staring from first_date up until last_date.
-        
+
         WARNING: For huge date ranges, this may be a large dataset, and take a long time to download. In these situations, get_historical (by week) may be a better option.
-        
+
         """
 
-        url = self.get_thingspeak_url(thingspeak_field, first_date, last_date, thingspeak_args)
+        url = self.get_thingspeak_url(
+            thingspeak_field,
+            first_date,
+            last_date,
+            thingspeak_args)
         return self.clean_data(thingspeak_field, pd.read_csv(url))
-        
+
     def get_historical(self,
                        weeks_to_get: int,
                        thingspeak_field: str,
@@ -265,7 +290,7 @@ class Channel():
                        thingspeak_args=None) -> pd.DataFrame:
         """
         Get data from the ThingSpeak API one week at a time up to weeks_to_get weeks in the past.
-        
+
         """
         to_week = start_date - timedelta(weeks=1)
         weekly_data = []
@@ -273,7 +298,8 @@ class Channel():
             for _ in range(weeks_to_get):
                 start_date = to_week  # DateTimes are immutable so this reference is not a problem
                 to_week = to_week - timedelta(weeks=1)
-                url = self.get_thingspeak_url(thingspeak_field, to_week, start_date, thingspeak_args)
+                url = self.get_thingspeak_url(
+                    thingspeak_field, to_week, start_date, thingspeak_args)
                 weekly_data.append(pd.read_csv(url))
                 weeks_to_get -= 1
 
@@ -281,7 +307,6 @@ class Channel():
 
         # Handle formatting the DataFrame column names
         return self.clean_data(thingspeak_field, weekly_data)
-
 
     def as_dict(self) -> dict:
         """

--- a/purpleair/channel.py
+++ b/purpleair/channel.py
@@ -7,13 +7,13 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 from urllib.parse import urlencode
+from urllib import request
 
 import pandas as pd
 import thingspeak
 
 from .api_data import (PARENT_PRIMARY_COLS, PARENT_SECONDARY_COLS,
                        CHILD_PRIMARY_COLS, CHILD_SECONDARY_COLS, THINGSPEAK_API_URL)
-
 
 class Channel():
     """
@@ -151,14 +151,112 @@ class Channel():
         self.created: Optional[int] = self.channel_data.get('Created')
         self.uptime: Optional[int] = self.channel_data.get('Uptime')
         self.is_owner: Optional[bool] = bool(self.channel_data.get('isOwner'))
-    
+        
+    @property
+    def created_date(self):
+        url = self.get_thingspeak_url('primary', start=datetime(1990,1,1), end=None, thingspeak_args={'results': 1}, dataformat='json')
+        data = json.loads(request.urlopen(url).read())
+        created_at = datetime.strptime(data['channel']['created_at'], '%Y-%m-%dT%H:%M:%SZ')
+        return created_at
+
+    def get_thingspeak_url(self, thingspeak_field, start, end=None, thingspeak_args=None, dataformat='csv'):
+        """Build the URL to fetch the thingspeak data
+        
+        thingspeak_args takes an optional list of additional arguments to send to the Thingspeak API. See here for more details: https://ww2.mathworks.cn/help/thingspeak/readdata.html
+        """
+
+        if thingspeak_field not in {'primary', 'secondary'}:
+            # pylint: disable=line-too-long
+            raise ValueError(
+                f'Invalid ThingSpeak key: {thingspeak_field}. Must be in {{"primary", "secondary"}}')
+
+        channel = self.tp_primary_channel if thingspeak_field == 'primary' else self.tp_secondary_channel
+        key = self.tp_primary_key if thingspeak_field == 'primary' else self.tp_secondary_key
+
+        # copy args to a local variable
+        if thingspeak_args:
+            thingspeak_args = thingspeak_args.copy()
+        else:
+            thingspeak_args = {}
+
+        default_args = {
+            'api_key': key,
+            'offset': 0,
+            'average': '',
+            'round': 2,
+        }
+
+        for key, val in default_args.items():
+            if key not in thingspeak_args:
+                thingspeak_args[key] = val
+        
+        thingspeak_args['start'] = start.strftime("%Y-%m-%d 00:00:00")
+        if end:
+            thingspeak_args['end'] = end.strftime("%Y-%m-%d 00:00:00")
+
+        base_url = THINGSPEAK_API_URL.format(channel=channel, dataformat=dataformat)
+        return base_url + urlencode(thingspeak_args)
+
+    def clean_data(self, thingspeak_field, data):
+
+        parent_cols = PARENT_PRIMARY_COLS if thingspeak_field == 'primary' else PARENT_SECONDARY_COLS
+        # pylint: disable=line-too-long
+        child_cols = CHILD_PRIMARY_COLS if thingspeak_field == 'primary' else CHILD_SECONDARY_COLS
+        columns = parent_cols if self.type == 'parent' else child_cols
+
+        data.rename(columns=columns, inplace=True)
+        data['created_at'] = pd.to_datetime(
+            data['created_at'], format='%Y-%m-%d %H:%M:%S %Z')
+
+        try:
+            data.index = data.pop('entry_id')
+        except KeyError:
+            # entry_id isn't always present. E.g. if you use timescale='nonstandard'
+            pass
+        return data
+
     def get_all_historical(self,
                            weeks_to_get: int,
                            start_date: datetime = datetime.now(),
                            thingspeak_args=None) -> pd.DataFrame:
+        """
+        Get all data (both primary and secondary) from the ThingSpeak API in weekly increments
+        
+        """
+                           
         primary = self.get_historical(weeks_to_get, 'primary', start_date, thingspeak_args)
         secondary = self.get_historical(weeks_to_get, 'secondary', start_date, thingspeak_args)
         return pd.merge(primary, secondary, how='inner', on='created_at')
+    
+    def get_all_historical_between(self,
+                                   first_date: datetime,
+                                   last_date: datetime = datetime.now(),
+                                   thingspeak_args=None) -> pd.DataFrame:
+        """
+        Get all data (both primary and secondary) from the ThingSpeak API all in one go, staring from first_date up until last_date.
+        
+        WARNING: For huge date ranges, this may be a large dataset, and take a long time to download. In these situations, get_historical (by week) may be a better option.
+        
+        """
+        primary = self.get_historical_between('primary', first_date, last_date, thingspeak_args)
+        secondary = self.get_historical_between('secondary', first_date, last_date, thingspeak_args)
+        return pd.merge(primary, secondary, how='inner', on='created_at')
+        
+    def get_historical_between(self,
+                               thingspeak_field: str,
+                               first_date: datetime,
+                               last_date: datetime = datetime.now(),
+                               thingspeak_args=None) -> pd.DataFrame:
+
+        """
+        Get data from the ThingSpeak API all in one go, staring from first_date up until last_date.
+        
+        WARNING: For huge date ranges, this may be a large dataset, and take a long time to download. In these situations, get_historical (by week) may be a better option.
+        
+        """
+
+        url = self.get_thingspeak_url(thingspeak_field, first_date, last_date, thingspeak_args)
+        return self.clean_data(thingspeak_field, pd.read_csv(url))
         
     def get_historical(self,
                        weeks_to_get: int,
@@ -168,65 +266,22 @@ class Channel():
         """
         Get data from the ThingSpeak API one week at a time up to weeks_to_get weeks in the past.
         
-        thingspeak_args takes an optional list of additional arguments to send to the Thingspeak API. See here for more details: https://ww2.mathworks.cn/help/thingspeak/readdata.html
         """
-        if thingspeak_field not in {'primary', 'secondary'}:
-            # pylint: disable=line-too-long
-            raise ValueError(
-                f'Invalid ThingSpeak key: {thingspeak_field}. Must be in {{"primary", "secondary"}}')
-
-        # Determine channel and key
-        # pylint: disable=line-too-long
-        channel = self.tp_primary_channel if thingspeak_field == 'primary' else self.tp_secondary_channel
-        key = self.tp_primary_key if thingspeak_field == 'primary' else self.tp_secondary_key
-
-        # Determine column columns
-        # pylint: disable=line-too-long
-        parent_cols = PARENT_PRIMARY_COLS if thingspeak_field == 'primary' else PARENT_SECONDARY_COLS
-        # pylint: disable=line-too-long
-        child_cols = CHILD_PRIMARY_COLS if thingspeak_field == 'primary' else CHILD_SECONDARY_COLS
-
-        columns = parent_cols if self.type == 'parent' else child_cols
         to_week = start_date - timedelta(weeks=1)
-        
-        # copy args to a local variable
-        if not thingspeak_args:
-            thingspeak_args = {}
-        default_args = {
-            'api_key': key,
-            'offset': 0,
-            'average': '',
-            'round': 2,
-        }
-        for key, val in default_args.items():
-            if key not in thingspeak_args:
-                thingspeak_args[key] = val
-        
         weekly_data = []
-        base_url = THINGSPEAK_API_URL.format(channel=channel)
         while weeks_to_get > 0:
             for _ in range(weeks_to_get):
                 start_date = to_week  # DateTimes are immutable so this reference is not a problem
                 to_week = to_week - timedelta(weeks=1)
-                thingspeak_args.update({
-                    'start': to_week.strftime("%Y-%m-%d 00:00:00"),
-                    'end' : start_date.strftime("%Y-%m-%d 00:00:00")
-                })
-                url = base_url + urlencode(thingspeak_args)
+                url = self.get_thingspeak_url(thingspeak_field, to_week, start_date, thingspeak_args)
                 weekly_data.append(pd.read_csv(url))
                 weeks_to_get -= 1
-        
+
         weekly_data = pd.concat(weekly_data)
-        # Handle formatting the DataFrame
-        weekly_data.rename(columns=columns, inplace=True)
-        weekly_data['created_at'] = pd.to_datetime(
-            weekly_data['created_at'], format='%Y-%m-%d %H:%M:%S %Z')
-        try:
-            weekly_data.index = weekly_data.pop('entry_id')
-        except KeyError:
-            # entry_id isn't always present. E.g. if you use timescale='nonstandard'
-            pass
-        return weekly_data
+
+        # Handle formatting the DataFrame column names
+        return self.clean_data(thingspeak_field, weekly_data)
+
 
     def as_dict(self) -> dict:
         """

--- a/purpleair/channel.py
+++ b/purpleair/channel.py
@@ -157,7 +157,15 @@ class Channel():
         self.created: Optional[int] = self.channel_data.get('Created')
         self.uptime: Optional[int] = self.channel_data.get('Uptime')
         self.is_owner: Optional[bool] = bool(self.channel_data.get('isOwner'))
-
+    
+    def get_all_historical(self,
+                           weeks_to_get: int,
+                           start_date: datetime = datetime.now(),
+                           thingspeak_args={}) -> pd.DataFrame:
+        primary = self.get_historical(weeks_to_get, 'primary', start_date, thingspeak_args)
+        secondary = self.get_historical(weeks_to_get, 'secondary', start_date, thingspeak_args)
+        return pd.merge(primary, secondary, how='inner', on='created_at')
+        
     def get_historical(self,
                        weeks_to_get: int,
                        thingspeak_field: str,

--- a/purpleair/channel.py
+++ b/purpleair/channel.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 from urllib.parse import urlencode
-from urllib import request
+from requests_cache import CachedSession
 
 import pandas as pd
 import thingspeak
@@ -168,10 +168,12 @@ class Channel():
                 1990, 1, 1), end=None, thingspeak_args={
                 'results': 1}, dataformat='json')
 
-        with json.loads(request.urlopen(url).read()) as data:
-            created_at = datetime.strptime(
-                data['channel']['created_at'],
-                '%Y-%m-%dT%H:%M:%SZ')
+        session = CachedSession(expire_after=timedelta(hours=1))
+        response = session.get(url)
+        data = json.loads(response.content)
+        created_at = datetime.strptime(
+            data['channel']['created_at'],
+            '%Y-%m-%dT%H:%M:%SZ')
         return created_at
 
     def get_thingspeak_url(

--- a/purpleair/sensor.py
+++ b/purpleair/sensor.py
@@ -54,6 +54,10 @@ class Sensor():
 
     @property
     def created_date(self):
+        """Gets the date the sensor's first known active date
+
+        Does so by getting the parent channel's `created_date` from thingspeak
+        """
         return self.parent.created_date
 
     # pylint: disable=no-self-use

--- a/purpleair/sensor.py
+++ b/purpleair/sensor.py
@@ -47,6 +47,10 @@ class Sensor():
         self.location: str = ''
         if self.parse_location:
             self.get_location()
+    
+    @property
+    def created_date(self):
+        return self.parent.created_date
 
     # pylint: disable=no-self-use
     def get_data(self, identifier: int) -> Optional[list]:

--- a/purpleair/sensor.py
+++ b/purpleair/sensor.py
@@ -21,7 +21,11 @@ class Sensor():
     Representation of a single PurpleAir sensor
     """
 
-    def __init__(self, identifier: int, json_data: Optional[list] = None, parse_location=False):
+    def __init__(
+            self,
+            identifier: int,
+            json_data: Optional[list] = None,
+            parse_location=False):
         self.data: Optional[list] = json_data \
             if json_data is not None else self.get_data(identifier)
 
@@ -47,7 +51,7 @@ class Sensor():
         self.location: str = ''
         if self.parse_location:
             self.get_location()
-    
+
     @property
     def created_date(self):
         return self.parent.created_date
@@ -127,7 +131,8 @@ class Sensor():
         if self.parent.current_pressure is None:
             return False
         if not self.parent.channel_data.get('Stats', None):
-            # Happens before stats because they will be missing if this is missing
+            # Happens before stats because they will be missing if this is
+            # missing
             return False
         if self.parent.last_modified_stats is None:
             return False

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1,7 +1,7 @@
 import unittest
 
 from purpleair import sensor
-
+from purpleair import api_data
 
 class TestChannelMethods(unittest.TestCase):
     """
@@ -24,6 +24,38 @@ class TestChannelMethods(unittest.TestCase):
         se.parent.get_historical(1, 'secondary')
         se.child.get_historical(1, 'primary')
         se.child.get_historical(1, 'secondary')
+    
+    def test_get_all_historical(self):
+        """
+        Test that we properly get both primary and secondary data in one go using the _all method
+        """
+        se = sensor.Sensor(2891)
+        
+        # parent sensor
+        parent_results = se.parent.get_all_historical(1)
+        
+        parent_columns = set(api_data.PARENT_PRIMARY_COLS.values())
+        parent_columns.update( api_data.PARENT_SECONDARY_COLS.values())
+        parent_columns.remove('entry_id') # remove entry_id
+
+        for field in parent_columns:
+            self.assertTrue(field in parent_results.columns)
+        
+        
+        # child sensor
+        child_results = se.child.get_all_historical(1)
+        
+        child_columns = set(api_data.CHILD_PRIMARY_COLS.values())
+        child_columns.update( api_data.CHILD_SECONDARY_COLS.values())
+        child_columns.remove('entry_id') # remove entry_id
+        
+        for field in child_columns:
+            self.assertTrue(field in child_results.columns)
+    
+    def test_get_mean_values(self):
+        se = sensor.Sensor(2891)
+        results = se.parent.get_historical(1, 'primary', thingspeak_args={'average': 'daily'})
+        self.assertTrue(len(results) in [7,8]) # either 7 or 8 results will be returned - depending on if we span 7 or 8 days with our 'week' time
 
     def test_as_dict(self):
         """


### PR DESCRIPTION
Sometimes you may want to pass additional arguments to the thingspeak API, e.g. `timesacale=daily` (get just one result per day or `average=60` (get average hourly results) etc.

This commit makes it possible to pass an additional dict of query args as per the Thingspeak API docs: https://ww2.mathworks.cn/help/thingspeak/readdata.html